### PR TITLE
[#3] password 중복 test 함수 channing 수정

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ export const bRules = Object.assign({
     return ((v) => REGEXP.PASSWORD_ALLOWED_TEXT.test(v) || msg);
   },
   password(msg = false) {
-    return ((v) => REGEXP.PASSWORD.test(v).test(v) || msg);
+    return ((v) => REGEXP.PASSWORD.test(v) || msg);
   },
   tel(msg = false) {
     return ((v) => REGEXP.TEL.test(v) || msg);


### PR DESCRIPTION
#3 

<img width="575" alt="스크린샷 2022-10-20 오후 1 20 40" src="https://user-images.githubusercontent.com/66895208/196855677-7ce1bea5-95c2-4cfd-a41d-be6242e4d9b5.png">


password validation에 test가 두번 써져있어서 동작하지 않더라고요 ㅎㅎ
작업하다가 우연히 발견했습니다. 

지금은 삭제한 상태입니다.