### PR TITLE
[#5] typescript 지원

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,31 @@
+export type ValidationResult = string | boolean;
+export type ValidationFunction = (value: any) => ValidationResult;
+
+interface IEssentials {
+  lengthEqual: (length: number, msg?: ValidationResult) => ValidationFunction;
+  lengthLess: (length: number, msg?: ValidationResult) => ValidationFunction;
+  lengthLessEqual: (length: number, msg?: ValidationResult) => ValidationFunction;
+  lengthGreater: (length: number, msg?: ValidationResult) => ValidationFunction;
+  lengthGreaterEqual: (length: number, msg?: ValidationResult) => ValidationFunction;
+  lengthBetween: (min: number, max: number, msg?: ValidationResult) => ValidationFunction;
+  lengthBetweenInclude: (min: number, max: number, msg?: ValidationResult) => ValidationFunction;
+  betweenNumber: (min: number, max: number, msg?: ValidationResult) => ValidationFunction;
+  betweenIncludeNumber: (min: number, max: number, msg?: ValidationResult) => ValidationFunction;
+  isNumber: (msg?: ValidationResult) => ValidationFunction;
+  isEmptyString: (msg?: ValidationResult) => ValidationFunction;
+  isNull: (msg?: ValidationResult) => ValidationFunction;
+  notNull: (msg?: ValidationResult) => ValidationFunction;
+}
+
+interface IbRules extends IEssentials {
+  required: (msg?: ValidationResult) => ValidationFunction;
+  businessNumber: (msg?: ValidationResult) => ValidationFunction;
+  email: (msg?: ValidationResult) => ValidationFunction;
+  loginId: (msg?: ValidationResult) => ValidationFunction;
+  passwordCharacter: (msg?: ValidationResult) => ValidationFunction;
+  password: (msg?: ValidationResult) => ValidationFunction;
+  tel: (msg?: ValidationResult) => ValidationFunction;
+  phone: (msg?: ValidationResult) => ValidationFunction;
+}
+
+export declare const bRules: IbRules;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.2",
   "description": "Barogo validation rules",
   "main": "index.js",
+  "types" : "index.d.ts",
   "scripts": {},
   "keywords": [
     "barogo",


### PR DESCRIPTION
typescript 지원을 위해 type을 추가했습니다.

사용 예)
```js
import type { ValidationFunction } from 'barogo-validation-rules';
import { bRules } from 'barogo-validation-rules';

const requiredRule = bRules.required(CONSTANTS.MESSAGE.NECESSARY);
const rules: {
  [name: string]: Array<ValidationFunction>;
} = {
  loginId: [requiredRule, bRules.loginId(CONSTANTS.MESSAGE.ID_MINIMUN)],
};
```
